### PR TITLE
1131/Switch to ignoring simple branches

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/McCabeVisitor.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/McCabeVisitor.kt
@@ -21,25 +21,21 @@ class McCabeVisitor(private val ignoreSimpleWhenEntries: Boolean) : DetektVisito
 	val mcc: Int
 		get() = _mcc
 
-	private fun inc() {
-		_mcc++
-	}
-
 	override fun visitNamedFunction(function: KtNamedFunction) {
-		inc()
+		_mcc++
 		super.visitNamedFunction(function)
 	}
 
 	override fun visitIfExpression(expression: KtIfExpression) {
-		inc()
+		_mcc++
 		if (expression.`else` != null) {
-			inc()
+			_mcc++
 		}
 		super.visitIfExpression(expression)
 	}
 
 	override fun visitLoopExpression(loopExpression: KtLoopExpression) {
-		inc()
+		_mcc++
 		super.visitLoopExpression(loopExpression)
 	}
 
@@ -55,9 +51,12 @@ class McCabeVisitor(private val ignoreSimpleWhenEntries: Boolean) : DetektVisito
 	}
 
 	override fun visitTryExpression(expression: KtTryExpression) {
-		inc()
+		_mcc++
 		_mcc += expression.catchClauses.size
-		expression.finallyBlock?.let { inc() }
+		expression.finallyBlock?.let {
+			_mcc++
+			Unit
+		}
 		super.visitTryExpression(expression)
 	}
 
@@ -67,7 +66,8 @@ class McCabeVisitor(private val ignoreSimpleWhenEntries: Boolean) : DetektVisito
 			if (lambdaArguments.size > 0) {
 				val lambdaArgument = lambdaArguments[0]
 				lambdaArgument.getLambdaExpression()?.bodyExpression?.let {
-					inc()
+					_mcc++
+					Unit
 				}
 			}
 		}

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/McCabeVisitor.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/McCabeVisitor.kt
@@ -16,32 +16,32 @@ import org.jetbrains.kotlin.psi.psiUtil.getCallNameExpression
  */
 class McCabeVisitor(private val ignoreSimpleWhenEntries: Boolean) : DetektVisitor() {
 
-	private var _mcc: Int = 0
-
-	val mcc: Int
-		get() = _mcc
+	var mcc: Int = 0
+		private set(value) {
+			field = value
+		}
 
 	override fun visitNamedFunction(function: KtNamedFunction) {
-		_mcc++
+		mcc++
 		super.visitNamedFunction(function)
 	}
 
 	override fun visitIfExpression(expression: KtIfExpression) {
-		_mcc++
+		mcc++
 		if (expression.`else` != null) {
-			_mcc++
+			mcc++
 		}
 		super.visitIfExpression(expression)
 	}
 
 	override fun visitLoopExpression(loopExpression: KtLoopExpression) {
-		_mcc++
+		mcc++
 		super.visitLoopExpression(loopExpression)
 	}
 
 	override fun visitWhenExpression(expression: KtWhenExpression) {
 		val entries = expression.extractEntries(ignoreSimpleWhenEntries)
-		_mcc += if (ignoreSimpleWhenEntries && entries.count() == 0) 1 else entries.count()
+		mcc += if (ignoreSimpleWhenEntries && entries.count() == 0) 1 else entries.count()
 		super.visitWhenExpression(expression)
 	}
 
@@ -51,10 +51,10 @@ class McCabeVisitor(private val ignoreSimpleWhenEntries: Boolean) : DetektVisito
 	}
 
 	override fun visitTryExpression(expression: KtTryExpression) {
-		_mcc++
-		_mcc += expression.catchClauses.size
+		mcc++
+		mcc += expression.catchClauses.size
 		expression.finallyBlock?.let {
-			_mcc++
+			mcc++
 			Unit
 		}
 		super.visitTryExpression(expression)
@@ -66,7 +66,7 @@ class McCabeVisitor(private val ignoreSimpleWhenEntries: Boolean) : DetektVisito
 			if (lambdaArguments.size > 0) {
 				val lambdaArgument = lambdaArguments[0]
 				lambdaArgument.getLambdaExpression()?.bodyExpression?.let {
-					_mcc++
+					mcc++
 					Unit
 				}
 			}

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/McCabeVisitor.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/McCabeVisitor.kt
@@ -44,8 +44,8 @@ class McCabeVisitor(private val ignoreSimpleWhenEntries: Boolean) : DetektVisito
 	}
 
 	override fun visitWhenExpression(expression: KtWhenExpression) {
-		val entriesSequence = expression.extractEntries(ignoreSimpleWhenEntries)
-		_mcc += entriesSequence.count()
+		val entries = expression.extractEntries(ignoreSimpleWhenEntries)
+		_mcc += if (ignoreSimpleWhenEntries && entries.count() == 0) 1 else entries.count()
 		super.visitWhenExpression(expression)
 	}
 

--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -77,7 +77,7 @@ complexity:
     active: true
     threshold: 10
     ignoreSingleWhenExpression: false
-    simpleWhenEntryWeight: 0.5
+    ignoreSimpleWhenEntries: false
   LabeledExpression:
     active: false
   LargeClass:

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/processors/ProjectComplexityProcessor.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/processors/ProjectComplexityProcessor.kt
@@ -16,7 +16,7 @@ val complexityKey = Key<Int>("complexity")
 class ComplexityVisitor : DetektVisitor() {
 
 	override fun visitKtFile(file: KtFile) {
-		with(McCabeVisitor()) {
+		with(McCabeVisitor(ignoreSimpleWhenEntries = false)) {
 			file.accept(this)
 			file.putUserData(complexityKey, mcc)
 		}

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/api/internal/McCabeVisitorSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/api/internal/McCabeVisitorSpec.kt
@@ -6,82 +6,112 @@ import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.given
 import org.jetbrains.spek.api.dsl.it
 
+private const val FUN_MCC = 1
+
 class McCabeVisitorSpec : Spek({
 
 	given("ignoreSimpleWhenEntries is false") {
-		val subject = McCabeVisitor(ignoreSimpleWhenEntries = false)
 
 		it("counts simple when branches as 1") {
 			val code = """
-				when (value) {
-					is Int -> bundle.putInt(transformedKey, value)
-					is String -> bundle.putString(transformedKey, value)
-					is Float -> bundle.putFloat(transformedKey, value)
-					is Double -> bundle.putDouble(transformedKey, value)
-					is Byte -> bundle.putByte(transformedKey, value)
-					is Short -> bundle.putShort(transformedKey, value)
-					is Long -> bundle.putLong(transformedKey, value)
-					is Boolean -> bundle.putBoolean(transformedKey, value)
-					else -> {
-						log("Unexpected type value")
-						throw IllegalArgumentException("Unexpected type value")
+				fun test() {
+					when (System.currentTimeMillis()) {
+						0 -> println("Epoch!")
+						1 -> println("1 past epoch.")
+						else -> println("Meh")
 					}
 				}
 			"""
+			val subject = McCabeVisitor(ignoreSimpleWhenEntries = false)
 
 			subject.visitFile(code.compile())
 
-			assertThat(subject.mcc).isEqualTo(1)
+			assertThat(subject.mcc).isEqualTo(FUN_MCC + 3)
+		}
+
+		it("counts block when branches as 1") {
+			val code = """
+				fun test() {
+					when (System.currentTimeMillis()) {
+						0 -> {
+							println("Epoch!")
+						}
+						1 -> println("1 past epoch.")
+						else -> println("Meh")
+					}
+				}
+			"""
+			val subject = McCabeVisitor(ignoreSimpleWhenEntries = false)
+
+			subject.visitFile(code.compile())
+
+			assertThat(subject.mcc).isEqualTo(FUN_MCC + 3)
 		}
 	}
 
 	given("ignoreSimpleWhenEntries is true") {
-		val subject = McCabeVisitor(ignoreSimpleWhenEntries = true)
+
+		it("counts a when with only simple branches as 1") {
+			val code = """
+				fun test() {
+					when (System.currentTimeMillis()) {
+						0 -> println("Epoch!")
+						1 -> println("1 past epoch.")
+						else -> println("Meh")
+					}
+				}
+			"""
+			val subject = McCabeVisitor(ignoreSimpleWhenEntries = true)
+
+			subject.visitFile(code.compile())
+
+			assertThat(subject.mcc).isEqualTo(FUN_MCC + 1)
+		}
 
 		it("does not count simple when branches") {
 			val code = """
-				when (value) {
-					is Int -> bundle.putInt(transformedKey, value)
-					is String -> bundle.putString(transformedKey, value)
-					is Float -> bundle.putFloat(transformedKey, value)
-					is Double -> bundle.putDouble(transformedKey, value)
-					is Byte -> bundle.putByte(transformedKey, value)
-					is Short -> bundle.putShort(transformedKey, value)
-					is Long -> {
-						log("I like long integers")
-						bundle.putLong(transformedKey, value)
-					}
-					is Boolean -> bundle.putBoolean(transformedKey, value)
-					else -> {
-						log("Unexpected type value")
-						throw IllegalArgumentException("Unexpected type value")
+				fun test() {
+					when (System.currentTimeMillis()) {
+						0 -> {
+							println("Epoch!")
+							println("yay")
+						}
+						1 -> {
+							println("1 past epoch!")
+						}
+						else -> println("Meh")
 					}
 				}
 			"""
+			val subject = McCabeVisitor(ignoreSimpleWhenEntries = true)
 
 			subject.visitFile(code.compile())
 
-			assertThat(subject.mcc).isEqualTo(2)
+			assertThat(subject.mcc).isEqualTo(FUN_MCC + 2)
 		}
 
-		it("counts a when expression with only simple entries as 1") {
+		it("counts block when branches as 1") {
+			val subject = McCabeVisitor(ignoreSimpleWhenEntries = true)
 			val code = """
-				when (value) {
-					is Int -> bundle.putInt(transformedKey, value)
-					is String -> bundle.putString(transformedKey, value)
-					is Float -> bundle.putFloat(transformedKey, value)
-					is Double -> bundle.putDouble(transformedKey, value)
-					is Byte -> bundle.putByte(transformedKey, value)
-					is Short -> bundle.putShort(transformedKey, value)
-					is Long -> bundle.putLong(transformedKey, value)
-					is Boolean -> bundle.putBoolean(transformedKey, value)
-					else -> throw IllegalArgumentException("Unexpected type value")
+				fun test() {
+					when (System.currentTimeMillis()) {
+						0 -> {
+							println("Epoch!")
+							println("yay!")
+						}
+						1 -> {
+							println("1 past epoch.")
+							println("yay?")
+						}
+						2 -> println("shrug")
+						else -> println("Meh")
+					}
 				}
 			"""
 
 			subject.visitFile(code.compile())
 
-			assertThat(subject.mcc).isEqualTo(1)
+			assertThat(subject.mcc).isEqualTo(FUN_MCC + 2)
 		}
 	}
 })

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/api/internal/McCabeVisitorSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/api/internal/McCabeVisitorSpec.kt
@@ -1,0 +1,89 @@
+package io.gitlab.arturbosch.detekt.api.internal
+
+import io.gitlab.arturbosch.detekt.test.KtTestCompiler
+import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.given
+import org.jetbrains.spek.api.dsl.it
+
+class McCabeVisitorSpec : Spek({
+
+	given("ignoreSimpleWhenEntries is false") {
+		val subject = McCabeVisitor(ignoreSimpleWhenEntries = false)
+
+		it("counts simple when branches as 1") {
+			val code = """
+				when (value) {
+					is Int -> bundle.putInt(transformedKey, value)
+					is String -> bundle.putString(transformedKey, value)
+					is Float -> bundle.putFloat(transformedKey, value)
+					is Double -> bundle.putDouble(transformedKey, value)
+					is Byte -> bundle.putByte(transformedKey, value)
+					is Short -> bundle.putShort(transformedKey, value)
+					is Long -> bundle.putLong(transformedKey, value)
+					is Boolean -> bundle.putBoolean(transformedKey, value)
+					else -> {
+						log("Unexpected type value")
+						throw IllegalArgumentException("Unexpected type value")
+					}
+				}
+			"""
+
+			subject.visitFile(code.compile())
+
+			assertThat(subject.mcc).isEqualTo(1)
+		}
+	}
+
+	given("ignoreSimpleWhenEntries is true") {
+		val subject = McCabeVisitor(ignoreSimpleWhenEntries = true)
+
+		it("does not count simple when branches") {
+			val code = """
+				when (value) {
+					is Int -> bundle.putInt(transformedKey, value)
+					is String -> bundle.putString(transformedKey, value)
+					is Float -> bundle.putFloat(transformedKey, value)
+					is Double -> bundle.putDouble(transformedKey, value)
+					is Byte -> bundle.putByte(transformedKey, value)
+					is Short -> bundle.putShort(transformedKey, value)
+					is Long -> {
+						log("I like long integers")
+						bundle.putLong(transformedKey, value)
+					}
+					is Boolean -> bundle.putBoolean(transformedKey, value)
+					else -> {
+						log("Unexpected type value")
+						throw IllegalArgumentException("Unexpected type value")
+					}
+				}
+			"""
+
+			subject.visitFile(code.compile())
+
+			assertThat(subject.mcc).isEqualTo(2)
+		}
+
+		it("counts a when expression with only simple entries as 1") {
+			val code = """
+				when (value) {
+					is Int -> bundle.putInt(transformedKey, value)
+					is String -> bundle.putString(transformedKey, value)
+					is Float -> bundle.putFloat(transformedKey, value)
+					is Double -> bundle.putDouble(transformedKey, value)
+					is Byte -> bundle.putByte(transformedKey, value)
+					is Short -> bundle.putShort(transformedKey, value)
+					is Long -> bundle.putLong(transformedKey, value)
+					is Boolean -> bundle.putBoolean(transformedKey, value)
+					else -> throw IllegalArgumentException("Unexpected type value")
+				}
+			"""
+
+			subject.visitFile(code.compile())
+
+			assertThat(subject.mcc).isEqualTo(1)
+		}
+	}
+})
+
+private fun String.compile() = KtTestCompiler.compileFromContent(this.trimIndent())

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/processors/ComplexityVisitorTest.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/processors/ComplexityVisitorTest.kt
@@ -31,6 +31,6 @@ internal class ComplexityVisitorTest {
 
 		val mcc = calcComplexity(path)
 
-		assertThat(mcc).isEqualTo(54)
+		assertThat(mcc).isEqualTo(56)
 	}
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexMethod.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexMethod.kt
@@ -23,7 +23,7 @@ import org.jetbrains.kotlin.psi.KtWhenExpression
  * @configuration threshold - MCC threshold for a method (default: 10)
  * @configuration ignoreSingleWhenExpression - Ignores a complex method if it only contains a single when expression.
  * (default: false)
- * @configuration simpleWhenEntryWeight - The weight used for simple (braceless) when entries. (default: 0.5)
+ * @configuration ignoreSimpleWhenEntries - Whether to ignore simple (braceless) when entries. (default: false)
  *
  * @active since v1.0.0
  * @author Artur Bosch
@@ -39,13 +39,13 @@ class ComplexMethod(config: Config = Config.empty,
 			Debt.TWENTY_MINS)
 
 	private val ignoreSingleWhenExpression = valueOrDefault(IGNORE_SINGLE_WHEN_EXPRESSION, false)
-	private val simpleWhenEntriesWeight = valueOrDefault(SIMPLE_WHEN_ENTRY_WEIGHT, 0.5)
+	private val ignoreSimpleWhenEntries = valueOrDefault(IGNORE_SIMPLE_WHEN_ENTRIES, false)
 
 	override fun visitNamedFunction(function: KtNamedFunction) {
 		if (hasSingleWhenExpression(function.bodyExpression)) {
 			return
 		}
-		val visitor = McCabeVisitor(simpleWhenEntriesWeight)
+		val visitor = McCabeVisitor(ignoreSimpleWhenEntries)
 		visitor.visitNamedFunction(function)
 		val mcc = visitor.mcc
 		if (mcc >= threshold) {
@@ -75,6 +75,6 @@ class ComplexMethod(config: Config = Config.empty,
 	companion object {
 		const val DEFAULT_ACCEPTED_METHOD_COMPLEXITY = 10
 		const val IGNORE_SINGLE_WHEN_EXPRESSION = "ignoreSingleWhenExpression"
-		const val SIMPLE_WHEN_ENTRY_WEIGHT = "simpleWhenEntryWeight"
+		const val IGNORE_SIMPLE_WHEN_ENTRIES = "ignoreSimpleWhenEntries"
 	}
 }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexMethodSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexMethodSpec.kt
@@ -25,7 +25,7 @@ class ComplexMethodSpec : Spek({
 
 			assertThat(subject.findings.first())
 					.isThresholded()
-					.withValue(19)
+					.withValue(20)
 					.withThreshold(10)
 		}
 	}
@@ -36,7 +36,7 @@ class ComplexMethodSpec : Spek({
 
 		it("does not report complex methods with a single when expression") {
 			val config = TestConfig(mapOf(
-					ComplexMethod.SIMPLE_WHEN_ENTRY_WEIGHT to "1.0",
+					ComplexMethod.IGNORE_SIMPLE_WHEN_ENTRIES to "1.0",
 					ComplexMethod.IGNORE_SINGLE_WHEN_EXPRESSION to "true"))
 			val subject = ComplexMethod(config, threshold = 4)
 
@@ -44,7 +44,7 @@ class ComplexMethodSpec : Spek({
 		}
 
 		it("reports all complex methods") {
-			val config = TestConfig(mapOf(ComplexMethod.SIMPLE_WHEN_ENTRY_WEIGHT to "1.0"))
+			val config = TestConfig(mapOf(ComplexMethod.IGNORE_SIMPLE_WHEN_ENTRIES to "1.0"))
 			val subject = ComplexMethod(config, threshold = 4)
 
 			assertThat(subject.lint(path)).hasSourceLocations(
@@ -56,8 +56,8 @@ class ComplexMethodSpec : Spek({
 			)
 		}
 
-		it("does not trip for a reasonable amount of simple when entries") {
-			val config = TestConfig(mapOf(ComplexMethod.SIMPLE_WHEN_ENTRY_WEIGHT to "0.5"))
+		it("does not trip for a reasonable amount of simple when entries when ignoreSimpleWhenEntries is true") {
+			val config = TestConfig(mapOf(ComplexMethod.IGNORE_SIMPLE_WHEN_ENTRIES to "true"))
 			val subject = ComplexMethod(config)
 			val code = """
 				internal fun Map<String, Any>.asBundle(): Bundle {

--- a/docs/pages/documentation/complexity.md
+++ b/docs/pages/documentation/complexity.md
@@ -87,9 +87,9 @@ Smaller methods can also be named much clearer which leads to improved readabili
 
    Ignores a complex method if it only contains a single when expression.
 
-* `simpleWhenEntryWeight` (default: `0.5`)
+* `ignoreSimpleWhenEntries` (default: `false`)
 
-   The weight used for simple (braceless) when entries.
+   Whether to ignore simple (braceless) when entries.
 
 ### LabeledExpression
 


### PR DESCRIPTION
Following discussion on #1135 this switches from a float MCC, which is not correct for an MCC, to an "ignore" flag for simple `when` entries.